### PR TITLE
Use bind instead of connect in the pathopub example.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,6 +101,7 @@ Zaytsev Roman Borisovich <roman.zaytsev.borisovich@gmail.com> (C++)
 Trevor Bernard <trevor.bernard@gmail.com> (Clojure)
 ygrek <ygrek@autistici.org> (OCaml)
 Matthew Wraith <wraithm@gmail.com> (Haskell, OCaml)
+Pieter du Preez <pdupreez@gmail.com> (C, Java, Python, Ruby)
 
 Errata and Suggestions
 ----------------------

--- a/examples/C/pathopub.c
+++ b/examples/C/pathopub.c
@@ -8,7 +8,7 @@ int main (int argc, char *argv [])
     zctx_t *context = zctx_new ();
     void *publisher = zsocket_new (context, ZMQ_PUB);
     if (argc == 2)
-        zsocket_connect (publisher, argv [1]);
+        zsocket_bind (publisher, argv [1]);
     else
         zsocket_bind (publisher, "tcp://*:5556");
 

--- a/examples/Java/pathopub.java
+++ b/examples/Java/pathopub.java
@@ -13,7 +13,7 @@ public class pathopub
         ZContext context = new ZContext();
         Socket publisher = context.createSocket(ZMQ.PUB);
         if (args.length == 1)
-            publisher.connect(args[0]);
+            publisher.bind(args[0]);
         else
             publisher.bind("tcp://*:5556");
 

--- a/examples/Python/pathopub.py
+++ b/examples/Python/pathopub.py
@@ -14,7 +14,7 @@ def main(url=None):
     ctx = zmq.Context.instance()
     publisher = ctx.socket(zmq.PUB)
     if url:
-        publisher.connect(url)
+        publisher.bind(url)
     else:
         publisher.bind("tcp://*:5556")
     # Ensure subscriber connection has time to complete

--- a/examples/Ruby/pathopub.rb
+++ b/examples/Ruby/pathopub.rb
@@ -11,7 +11,7 @@ TOPIC_COUNT = 1_000
 
 publisher = context.socket(ZMQ::PUB)
 if ARGV[0]
-  publisher.connect(ARGV[0])
+  publisher.bind(ARGV[0])
 else
   publisher.bind("tcp://*:5556")
 end


### PR DESCRIPTION
The pathopub example allows one to supply a URL, but
erroneously then calls connect instead of bind on
the URL. The mistake was made in all the programming
languages, in which the pathopub example was implemented.

This patch fixes all the implemented pathopub examples.