### PR TITLE
replaced 'int64_t more' with 'int more' in C/C++ Multipart examples

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -118,3 +118,4 @@ Matthew Horsfall <WolfSage@gmail.com>
 Nathan Stocks
 Ondrej Kupka <ondra.cap@gmail.com>
 Sebastian Thiel <byronimo@gmail.com>
+Scott Watson

--- a/articles/src/multithreading/zhelpers.h
+++ b/articles/src/multithreading/zhelpers.h
@@ -119,7 +119,7 @@ s_dump (void *socket)
         }
         printf ("\n");
 
-        int64_t more;           //  Multipart detection
+        int more;        //  Multipart detection
         size_t more_size = sizeof (more);
         zmq_getsockopt (socket, ZMQ_RCVMORE, &more, &more_size);
         zmq_msg_close (&message);

--- a/articles/src/multithreading/zmsg.c
+++ b/articles/src/multithreading/zmsg.c
@@ -230,7 +230,7 @@ zmsg_recv (void *socket)
 
         zmq_msg_close (&message);
 
-        int64_t more;
+        int more;
         size_t more_size = sizeof (more);
         zmq_getsockopt (socket, ZMQ_RCVMORE, &more, &more_size);
         if (!more)

--- a/examples/C++/rrbroker.cpp
+++ b/examples/C++/rrbroker.cpp
@@ -26,7 +26,7 @@ int main (int argc, char *argv[])
     //  Switch messages between sockets
     while (1) {
         zmq::message_t message;
-        int64_t more;           //  Multipart detection
+        int more;               //  Multipart detection
 
         zmq::poll (&items [0], 2, -1);
         

--- a/examples/C++/wuproxy.cpp
+++ b/examples/C++/wuproxy.cpp
@@ -25,7 +25,7 @@ int main (int argc, char *argv[])
     while (1) {
         while (1) {
             zmq::message_t message;
-            int64_t more;
+            int more;
             size_t more_size = sizeof (more);
 
             //  Process all parts of the message

--- a/examples/C++/zmsg.hpp
+++ b/examples/C++/zmsg.hpp
@@ -110,7 +110,7 @@ public:
             data[message.size()] = 0;
             push_back((char *)data.c_str());
          }
-         int64_t more = 0;
+         int more = 0;
          size_t more_size = sizeof(more);
          socket.getsockopt(ZMQ_RCVMORE, &more, &more_size);
          if (!more) {

--- a/examples/C/zhelpers.h
+++ b/examples/C/zhelpers.h
@@ -99,7 +99,7 @@ s_dump (void *socket)
         }
         printf ("\n");
 
-        int64_t more;           //  Multipart detection
+        int more;        //  Multipart detection
         more = 0;
         size_t more_size = sizeof (more);
         zmq_getsockopt (socket, ZMQ_RCVMORE, &more, &more_size);


### PR DESCRIPTION
Using int64_t on architectures where 'int' is 32bit yields unknown results.

getsockopt (zmq4 and 3)  looks like:
      *((int*) optval_) = rcvmore ? 1 : 0;
      *optvallen_ = sizeof (int);

In zmq2 it was correct for that version:
        *((int64_t*) optval_) = rcvmore ? 1 : 0;
        *optvallen_ = sizeof (int64_t);
