### PR TITLE
Replace lbbroker.py to fix issue #502.

### DIFF
--- a/examples/Python/lbbroker.py
+++ b/examples/Python/lbbroker.py
@@ -1,180 +1,108 @@
 """
+Load-balancing broker
 
-   Least-recently used (LRU) queue device
-   Clients and workers are shown here in-process
+Clients and workers are shown here in-process.
 
-   Author: Guillaume Aubert (gaubert) <guillaume(dot)aubert(at)gmail(dot)com>
-
+Author: Brandon Carpenter (hashstat) <brandon(dot)carpenter(at)pnnl(dot)gov>
 """
+
 from __future__ import print_function
 
-import threading
-import time
+import multiprocessing
+
 import zmq
+
 
 NBR_CLIENTS = 10
 NBR_WORKERS = 3
 
-def worker_thread(worker_url, context, i):
-    """ Worker using REQ socket to do LRU routing """
 
-    socket = context.socket(zmq.REQ)
+def client_task(ident):
+    """Basic request-reply client using REQ socket."""
+    socket = zmq.Context().socket(zmq.REQ)
+    socket.identity = u"Client-{}".format(ident).encode("ascii")
+    socket.connect("ipc://frontend.ipc")
 
-    # Set the worker identity
-    socket.identity = (u"Worker-%d" % (i)).encode('ascii')
-
-    socket.connect(worker_url)
-
-    # Tell the borker we are ready for work
-    socket.send(b"READY")
-
-    try:
-        while True:
-
-            address = socket.recv()
-            empty = socket.recv()
-            request = socket.recv()
-
-            print("%s: %s\n" % (socket.identity.decode('ascii'), request.decode('ascii')), end='')
-
-            socket.send(address, zmq.SNDMORE)
-            socket.send(b"", zmq.SNDMORE)
-            socket.send(b"OK")
-
-    except zmq.ContextTerminated:
-        # context terminated so quit silently
-        return
-
-
-def client_thread(client_url, context, i):
-    """ Basic request-reply client using REQ socket """
-
-    socket = context.socket(zmq.REQ)
-
-    socket.identity = (u"Client-%d" % (i)).encode('ascii')
-
-    socket.connect(client_url)
-
-    #  Send request, get reply
+    # Send request, get reply
     socket.send(b"HELLO")
     reply = socket.recv()
+    print("{}: {}".format(socket.identity.decode("ascii"),
+                          reply.decode("ascii")))
 
-    print("%s: %s\n" % (socket.identity.decode('ascii'), reply.decode('ascii')), end='')
+
+def worker_task(ident):
+    """Worker task, using a REQ socket to do load-balancing."""
+    socket = zmq.Context().socket(zmq.REQ)
+    socket.identity = u"Worker-{}".format(ident).encode("ascii")
+    socket.connect("ipc://backend.ipc")
+
+    # Tell broker we're ready for work
+    socket.send(b"READY")
+
+    while True:
+        address, empty, request = socket.recv_multipart()
+        print("{}: {}".format(socket.identity.decode("ascii"),
+                              request.decode("ascii")))
+        socket.send_multipart([address, b"", b"OK"])
 
 
 def main():
-    """ main method """
-
-    url_worker = "inproc://workers"
-    url_client = "inproc://clients"
-    client_nbr = NBR_CLIENTS
-
-    # Prepare our context and sockets
-    context = zmq.Context()
+    """Load balancer main loop."""
+    # Prepare context and sockets
+    context = zmq.Context.instance()
     frontend = context.socket(zmq.ROUTER)
-    frontend.bind(url_client)
+    frontend.bind("ipc://frontend.ipc")
     backend = context.socket(zmq.ROUTER)
-    backend.bind(url_worker)
+    backend.bind("ipc://backend.ipc")
 
-
-
-    # create workers and clients threads
-    for i in range(NBR_WORKERS):
-        thread = threading.Thread(target=worker_thread, args=(url_worker, context, i, ))
-        thread.start()
-
+    # Start background tasks
+    def start(task, *args):
+        process = multiprocessing.Process(target=task, args=args)
+        process.daemon = True
+        process.start()
     for i in range(NBR_CLIENTS):
-        thread_c = threading.Thread(target=client_thread, args=(url_client, context, i, ))
-        thread_c.start()
+        start(client_task, i)
+    for i in range(NBR_WORKERS):
+        start(worker_task, i)
 
-    # Logic of LRU loop
-    # - Poll backend always, frontend only if 1+ worker ready
-    # - If worker replies, queue worker as ready and forward reply
-    # to client if necessary
-    # - If client requests, pop next worker and send request to it
-
-    # Queue of available workers
-    available_workers = 0
-    workers_list      = []
-
-    # init poller
+    # Initialize main loop state
+    count = NBR_CLIENTS
+    workers = []
     poller = zmq.Poller()
-
-    # Always poll for worker activity on backend
+    # Only poll for requests from backend until workers are available
     poller.register(backend, zmq.POLLIN)
 
-    # Poll front-end only if we have available workers
-    poller.register(frontend, zmq.POLLIN)
-
     while True:
+        sockets = dict(poller.poll())
 
-        socks = dict(poller.poll())
+        if backend in sockets:
+            # Handle worker activity on the backend
+            request = backend.recv_multipart()
+            worker, empty, client = request[:3]
+            if not workers:
+                # Poll for clients now that a worker is available
+                poller.register(frontend, zmq.POLLIN)
+            workers.append(worker)
+            if client != b"READY" and len(request) > 3:
+                # If client reply, send rest back to frontend
+                empty, reply = request[3:]
+                frontend.send_multipart([client, b"", reply])
+                count -= 1
+                if not count:
+                    break
 
-        # Handle worker activity on backend
-        if (backend in socks and socks[backend] == zmq.POLLIN):
+        if frontend in sockets:
+            # Get next client request, route to last-used worker
+            client, empty, request = frontend.recv_multipart()
+            worker = workers.pop(0)
+            backend.send_multipart([worker, b"", client, b"", request])
+            if not workers:
+                # Don't poll clients if no workers are available
+                poller.unregister(frontend)
 
-            # Queue worker address for LRU routing
-            worker_addr  = backend.recv()
-
-            assert available_workers < NBR_WORKERS
-
-            # add worker back to the list of workers
-            available_workers += 1
-            workers_list.append(worker_addr)
-
-            #   Second frame is empty
-            empty = backend.recv()
-            assert empty == b""
-
-            # Third frame is READY or else a client reply address
-            client_addr = backend.recv()
-
-            # If client reply, send rest back to frontend
-            if client_addr != b"READY":
-
-                # Following frame is empty
-                empty = backend.recv()
-                assert empty == b""
-
-                reply = backend.recv()
-
-                frontend.send(client_addr, zmq.SNDMORE)
-                frontend.send(b"", zmq.SNDMORE)
-                frontend.send(reply)
-
-                client_nbr -= 1
-
-                if client_nbr == 0:
-                    break  # Exit after N messages
-
-        # poll on frontend only if workers are available
-        if available_workers > 0:
-
-            if (frontend in socks and socks[frontend] == zmq.POLLIN):
-                # Now get next client request, route to LRU worker
-                # Client request is [address][empty][request]
-                client_addr = frontend.recv()
-
-                empty = frontend.recv()
-                assert empty == b""
-
-                request = frontend.recv()
-
-                #  Dequeue and drop the next worker address
-                available_workers -= 1
-                worker_id = workers_list.pop()
-
-                backend.send(worker_id, zmq.SNDMORE)
-                backend.send(b"", zmq.SNDMORE)
-                backend.send(client_addr, zmq.SNDMORE)
-                backend.send(b"", zmq.SNDMORE)
-                backend.send(request)
-
-
-    # Out of infinite loop: do some housekeeping
-
-    frontend.close()
+    # Clean up
     backend.close()
+    frontend.close()
     context.term()
 
 


### PR DESCRIPTION
Fixes issue #502.

1. Uses list as queue, rather than stack, to hold workers.
2. Front-end router socket is only polled when workers are available.
3. Holds more closely to C example:
   * Functions are declared in the same order
   * Uses ipc sockets
   * Starts workers and clients using multiprocessing to limit influence of Global Interpreter Lock (GIL)
4. Follows PEP-08 style guidelines
5. Less verbose