### PR TITLE
Define srandom and random for WIN32

### DIFF
--- a/examples/C/zhelpers.h
+++ b/examples/C/zhelpers.h
@@ -32,13 +32,15 @@
 #   error "Please upgrade to ZeroMQ/3.2 for these examples"
 #endif
 
-//  Provide random number from 0..(num-1)
+//  On some version of Windows, POSIX subsystem is not installed by default.
+//  So define srandom and random ourself.
 #if (defined (WIN32))
-#   define randof(num)  (int) ((float) (num) * rand () / (RAND_MAX + 1.0))
-#else
-#   define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
+#   define srandom srand
+#   define random rand
 #endif
 
+//  Provide random number from 0..(num-1)
+#define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 
 //  Receive 0MQ string from socket and convert into C string
 //  Caller must free returned string. Returns NULL if the context


### PR DESCRIPTION
Since the POSIX subsystem is not installed by default on Win7,  and there are so many references to this two interfaces in C examples, I added two macros:
>#define srandom srand
#define random rand

