### PR TITLE
C++ Examples: s_clock() & MajorDomo

### DIFF
--- a/examples/C++/mdwrkapi.hpp
+++ b/examples/C++/mdwrkapi.hpp
@@ -214,9 +214,9 @@ public:
                 connect_to_broker ();
             }
             //  Send HEARTBEAT if it's time
-            if (s_clock () > m_heartbeat_at) {
+            if (s_clock () >= m_heartbeat_at) {
                 send_to_broker ((char*)MDPW_HEARTBEAT, "", NULL);
-                m_heartbeat_at = s_clock () + m_heartbeat;
+                m_heartbeat_at += m_heartbeat;
             }
         }
         if (s_interrupted)

--- a/examples/C++/zhelpers.hpp
+++ b/examples/C++/zhelpers.hpp
@@ -176,9 +176,13 @@ static int64_t
 s_clock (void)
 {
 #if (defined (_WIN32))
-    SYSTEMTIME st;
-    GetSystemTime (&st);
-    return (int64_t) st.wSecond * 1000 + st.wMilliseconds;
+	FILETIME fileTime;
+	GetSystemTimeAsFileTime(&fileTime);
+	unsigned __int64 largeInt = fileTime.dwHighDateTime;
+	largeInt <<= 32;
+	largeInt |= fileTime.dwLowDateTime;
+	largeInt /= 10000; // FILETIME is in units of 100 nanoseconds
+	return (int64_t)largeInt;
 #else
     struct timeval tv;
     gettimeofday (&tv, NULL);


### PR DESCRIPTION
* zhelpers.hpp: s_clock() on Windows would wrap every minute, causing havoc for any but the most optimistic scenarios. Tested against MajorDomo, which would constantly drop its registered workers.
* Plenty of fixes to MajorDomo, for heartbeat precision and a couple of crashes.