### PR TITLE
Updating C# Examples

### DIFF
--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -176,6 +176,8 @@ Use with HWClient.
 
 #### [SPQueue](https://github.com/metadings/zguide/blob/master/examples/C%23/spqueue.cs), [SPWorker](https://github.com/metadings/zguide/blob/master/examples/C%23/spworker.cs)
 
+Use with LPClient.
+
 ```
 	Usage: ./ZGuideExamples.exe SPQueue
 
@@ -183,6 +185,8 @@ Use with HWClient.
 ```
 
 #### [PPQueue](https://github.com/metadings/zguide/blob/master/examples/C%23/ppqueue.cs), [PPWorker](https://github.com/metadings/zguide/blob/master/examples/C%23/ppworker.cs)
+
+Use with LPClient.
 
 ```
 	Usage: ./ZGuideExamples.exe PPQueue

--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -97,7 +97,9 @@ Use with TaskVent.
 Use with HWClient.
 
 ```
-	Usage: ./ZGuideExamples.exe Interrupt
+	Usage: ./ZGuideExamples.exe Interrupt [Name]
+
+        Name      Your Name
 ```
 
 #### [MTServer](https://github.com/metadings/zguide/blob/master/examples/C%23/mtserver.cs), [MTRelay](https://github.com/metadings/zguide/blob/master/examples/C%23/mtrelay.cs)
@@ -126,12 +128,8 @@ Use with HWClient.
 
 #### [Identity](https://github.com/metadings/zguide/blob/master/examples/C%23/identity.cs)
 
-Use with HWClient.
-
 ```
-	Usage: ./ZGuideExamples.exe Identity [Name]
-
-        Name      Your Name
+	Usage: ./ZGuideExamples.exe Identity
 ```
 
 #### [RTReq](https://github.com/metadings/zguide/blob/master/examples/C%23/rtreq.cs), [RTDealer](https://github.com/metadings/zguide/blob/master/examples/C%23/rtdealer.cs)

--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -76,8 +76,10 @@ Usage: ./ZGuideExamples.exe [--option=++] [--option=tcp://192.168.1.1:8080] <com
 
 #### [MsgQueue](https://github.com/metadings/zguide/blob/master/examples/C%23/msgqueue.cs)
 
+Use with RRServer and RRClient.
+
 ```
-	Usage: ./ZGuideExamples.exe msgqueue
+	Usage: ./ZGuideExamples.exe MsgQueue
 ```
 
 #### [TaskWork2](https://github.com/metadings/zguide/blob/master/examples/C%23/taskwork2.cs), [TaskSink2](https://github.com/metadings/zguide/blob/master/examples/C%23/tasksink2.cs)
@@ -124,8 +126,12 @@ Use with HWClient.
 
 #### [Identity](https://github.com/metadings/zguide/blob/master/examples/C%23/identity.cs)
 
+Use with HWClient.
+
 ```
-	Usage: ./ZGuideExamples.exe Identity
+	Usage: ./ZGuideExamples.exe Identity [Name]
+
+        Name      Your Name
 ```
 
 #### [RTReq](https://github.com/metadings/zguide/blob/master/examples/C%23/rtreq.cs), [RTDealer](https://github.com/metadings/zguide/blob/master/examples/C%23/rtdealer.cs)
@@ -154,7 +160,8 @@ Use with HWClient.
 	Usage: ./ZGuideExamples.exe Peering1 World Receiver0
 				                Peering1 Receiver0 World
 
-	Usage: ./ZGuideExamples.exe Peering2
+	Usage: ./ZGuideExamples.exe Peering2 World Receiver0
+				                Peering2 Receiver0 World
 ```
 
 #### [LPClient](https://github.com/metadings/zguide/blob/master/examples/C%23/lpclient.cs), [LPServer](https://github.com/metadings/zguide/blob/master/examples/C%23/lpserver.cs)
@@ -205,12 +212,12 @@ Use with HWClient.
 	Usage: ./ZGuideExamples.exe FLServer2 [Endpoint]
 
 	    Endpoint  Where FLServer2 should bind on.
-	              Default is tcp://127.0.0.1:7780
+	              Default is tcp://127.0.0.1:7781
 
 	Usage: ./ZGuideExamples.exe FLClient2 [Endpoint] ...
 
 	    Endpoint  Where FLClient2 should connect to.
-	              Default is tcp://127.0.0.1:7780
+	              Default is tcp://127.0.0.1:7781
 ```
 
 #### [FLServer3](https://github.com/metadings/zguide/blob/master/examples/C%23/flserver3.cs), [FLClient3](https://github.com/metadings/zguide/blob/master/examples/C%23/flclient3.cs), [FLCliApi.FreelanceClient](https://github.com/metadings/zguide/blob/master/examples/C%23/flcliapi.cs)

--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -3,6 +3,9 @@ ZeroMQ Examples in C#
 
 Hello! I've made some new examples for C#.
 
+Also read: [ZeroMQ - The Guide](http://zguide.zeromq.org/page:all)
+Current version: [ZeroMQ - The Guide Examples](https://github.com/metadings/zguide/tree/master/examples/C%23/)
+
 You can open the `ZGuideExamples.*.csproj` in Visual C# on Windows or in MonoDevelop on Linux.  
 Add a Reference to the project [`/zeromq/clrzmq4`](http://github.com/zeromq/clrzmq4) (or the release ZeroMQ.dll).
 

--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -3,8 +3,7 @@ ZeroMQ Examples in C#
 
 Hello! I've made some new examples for C#.
 
-Also read: [ZeroMQ - The Guide](http://zguide.zeromq.org/page:all)
-Current version: [ZeroMQ - The Guide Examples](https://github.com/metadings/zguide/tree/master/examples/C%23/)
+Also read: [ZeroMQ - The Guide](http://zguide.zeromq.org/page:all). Current version: [ZeroMQ - The Guide Examples](https://github.com/metadings/zguide/tree/master/examples/C%23/).
 
 You can open the `ZGuideExamples.*.csproj` in Visual C# on Windows or in MonoDevelop on Linux.  
 Add a Reference to the project [`/zeromq/clrzmq4`](http://github.com/zeromq/clrzmq4) (or the release ZeroMQ.dll).
@@ -224,7 +223,7 @@ Use with HWClient.
 #### [FLServer3](https://github.com/metadings/zguide/blob/master/examples/C%23/flserver3.cs), [FLClient3](https://github.com/metadings/zguide/blob/master/examples/C%23/flclient3.cs), [FLCliApi.FreelanceClient](https://github.com/metadings/zguide/blob/master/examples/C%23/flcliapi.cs)
 
 ```
-	Usage: ./ZGuideExamples.exe FLServer3
+	Usage: ./ZGuideExamples.exe [--verbose] FLServer3
 
 	Usage: ./ZGuideExamples.exe FLClient3 [Name] [Endpoint]
 

--- a/examples/C#/flclient1.cs
+++ b/examples/C#/flclient1.cs
@@ -10,7 +10,8 @@ namespace ZeroMQ.Test
 {
 	static partial class Program
 	{
-		static readonly TimeSpan FLClient1_REQUEST_TIMEOUT = TimeSpan.FromMilliseconds(1000);
+		static readonly TimeSpan FLClient1_REQUEST_TIMEOUT = TimeSpan.FromMilliseconds(2500);
+
 		static int FLClient1_MAX_RETRIES = 3;	// Before we abandon
 
 		public static void FLClient1(IDictionary<string, string> dict, string[] args)

--- a/examples/C#/flserver3.cs
+++ b/examples/C#/flserver3.cs
@@ -52,7 +52,7 @@ namespace ZeroMQ.Test
 
 						using (request)
 						{
-							Console_WriteZMessage(request, "Receiving");
+							if (Verbose) Console_WriteZMessage(request, "Receiving");
 
 							// Frame 0: identity of client
 							// Frame 1: PING, or client control frame
@@ -77,7 +77,7 @@ namespace ZeroMQ.Test
 
 						response.Prepend(identity);
 
-						Console_WriteZMessage(response, "Sending  ");
+						if (Verbose) Console_WriteZMessage(response, "Sending  ");
 						if (!server.Send(response, out error))
 						{
 							if (error == ZError.ETERM)

--- a/examples/C#/lpclient.cs
+++ b/examples/C#/lpclient.cs
@@ -28,7 +28,7 @@ namespace ZeroMQ.Test
 
 			var requester = new ZSocket(context, ZSocketType.REQ);
 			requester.IdentityString = name;
-			// requester.Linger = TimeSpan.FromMilliseconds(1);
+			requester.Linger = TimeSpan.FromMilliseconds(1);
 
 			if (!requester.Connect("tcp://127.0.0.1:5555", out error))
 			{
@@ -130,10 +130,7 @@ namespace ZeroMQ.Test
 									if (null == (requester = LPClient_CreateZSocket(context, name, out error)))
 									{
 										if (error == ZError.ETERM)
-										{
-											retries_left = 0;
-											break;	// Interrupted
-										}
+											return;	// Interrupted
 										throw new ZException(error);
 									}
 
@@ -146,10 +143,7 @@ namespace ZeroMQ.Test
 										if (!requester.Send(outgoing, out error))
 										{
 											if (error == ZError.ETERM)
-											{
-												retries_left = 0;
-												break;	// Interrupted
-											}
+												return;	// Interrupted
 											throw new ZException(error);
 										}
 									}
@@ -158,10 +152,7 @@ namespace ZeroMQ.Test
 								}
 
 								if (error == ZError.ETERM)
-								{
-									retries_left = 0;
-									break;	// Interrupted
-								}
+									return;	// Interrupted
 								throw new ZException(error);
 							}
 						}

--- a/examples/C#/suisnail.cs
+++ b/examples/C#/suisnail.cs
@@ -122,7 +122,7 @@ namespace ZeroMQ.Test
 				subpipe.Frontend.ReceiveFrame();
 				pubpipe.Frontend.Send(new ZFrame("break"));
 
-				Thread.Sleep(100);
+				Thread.Sleep(5000);
 			}
 		}
 	}


### PR DESCRIPTION
Hello Pieter! I've updated some examples: LPClient, FLClient1, FLServer3 and SuiSnail...
Also I'm using [`new ZSocket`](https://github.com/zeromq/clrzmq4/blob/master/ZSocket.cs#L52), which is now a redirection of `ZSocket.Create`.

Do you want to run the command again, to see whether it finds the hwserver example? 

I also like to change the css, `.code`, to not wrap the code examples. Where do I add a css rule to the template, which is being added to the zguide and the examples?