### PR TITLE
"ipc" doesn't yet work on windows.

### DIFF
--- a/examples/C++/rtreq.cpp
+++ b/examples/C++/rtreq.cpp
@@ -15,7 +15,13 @@ worker_thread (void *arg) {
     
     //  We use a string identity for ease here
     s_set_id (worker);
+    
+    // "ipc" doesn't yet work on windows.
+#if (defined(_WIN32))
+    worker.connect("tcp://localhost:5671");
+#else
     worker.connect("ipc://routing.ipc");
+#endif
 
     int total = 0;
     while (1) {
@@ -41,7 +47,13 @@ worker_thread (void *arg) {
 int main () {
     zmq::context_t context(1);
     zmq::socket_t client (context, ZMQ_ROUTER);
+    
+    // "ipc" doesn't yet work on windows.
+#if (defined(_WIN32))
+    client.bind("tcp://*:5671");
+#else
     client.bind("ipc://routing.ipc");
+#endif
 
     int worker_nbr;
     for (worker_nbr = 0; worker_nbr < NBR_WORKERS; worker_nbr++) {

--- a/examples/Python/rtreq.py
+++ b/examples/Python/rtreq.py
@@ -22,7 +22,7 @@ def worker_thread(context=None):
 
     # We use a string identity for ease here
     zhelpers.set_id(worker)
-    worker.connect("ipc://routing.ipc")
+    worker.connect("tcp://localhost:5671")
 
     total = 0
     while True:
@@ -43,7 +43,7 @@ def worker_thread(context=None):
 
 context = zmq.Context.instance()
 client = context.socket(zmq.ROUTER)
-client.bind("ipc://routing.ipc")
+client.bind("tcp://*:5671")
 
 for _ in range(NBR_WORKERS):
     Thread(target=worker_thread).start()


### PR DESCRIPTION
According to [zguide](http://zguide.zeromq.org/page:all#Unicast-Transports):
>The inter-process ipc transport is disconnected, like tcp. It has one limitation: it does not yet work on Windows.

So I fixed two of the examples I came across.