### PR TITLE
fixed bug with debug mode

### DIFF
--- a/examples/Python/mdwrkapi.py
+++ b/examples/Python/mdwrkapi.py
@@ -132,7 +132,8 @@ class MajorDomoWorker(object):
                     # up to a null part, but for now, just save one...
                     self.reply_to = msg.pop(0)
                     # pop empty
-                    assert msg.pop(0) == ''
+                    empty = msg.pop(0)
+                    assert empty == ''
 
                     return msg # We have a request to process
                 elif command == MDP.W_HEARTBEAT:


### PR DESCRIPTION
using `assert msg.pop(0) == ''` shows different behaviours depending on whether you run the code with `python -O` or simply with `python` (differently said, if you run in debug mode or not...).

In particular when not in debug mode with `worker.recv()` you get a `request` obejct starting with an empty element.