### PR TITLE
clarify fork semantics

### DIFF
--- a/chapter1.txt
+++ b/chapter1.txt
@@ -355,9 +355,9 @@ Having seen some examples, you must be eager to start using ZeroMQ in some apps.
 
 ZeroMQ applications always start by creating a //context//, and then using that for creating sockets. In C, it's the {{zmq_ctx_new[3]}} call. You should create and use exactly one context in your process. Technically, the context is the container for all sockets in a single process, and acts as the transport for {{inproc}} sockets, which are the fastest way to connect threads in one process. If at runtime a process has two contexts, these are like separate ZeroMQ instances. If that's explicitly what you want, OK, but otherwise remember:
 
-**Do one {{zmq_ctx_new[3]}} at the start of your main line code, and one {{zmq_ctx_destroy[3]}} at the end.**
+**Call {{zmq_ctx_new[3]}} once at the start of a process, and {{zmq_ctx_destroy[3]}} once at the end.**
 
-If you're using the {{fork()}} system call, each process needs its own context. If you do {{zmq_ctx_new[3]}} in the main process before calling {{fork()}}, the child processes get their own contexts. In general, you want to do the interesting stuff in the child processes and just manage these from the parent process.
+If you're using the {{fork()}} system call, do {{zmq_ctx_new[3]}} //after// the fork and at the beginning of the child process code. In general, you want to do interesting (ZeroMQ) stuff in the children, and boring process management in the parent.
 
 +++ Making a Clean Exit
 


### PR DESCRIPTION
I initially read this section of the guide to mean that one should create a single context before `fork`, and share it across all children.

Several explosions and much reading of the mailing list archives later, I now understand that the recommendation is actually the opposite: create contexts _after_ `fork`, in each child that needs to do zeromq work, and leave the parent just for process management.

After confirming with a few other individuals that the wording in the section was a little confusing, I decided to take a stab at rewording it in line with the mailing list threads I found.

Thanks!

http://lists.zeromq.org/pipermail/zeromq-dev/2011-December/014900.html
http://lists.zeromq.org/pipermail/zeromq-dev/2010-September/006089.html
http://lists.zeromq.org/pipermail/zeromq-dev/2012-October/018887.html
http://lists.zeromq.org/pipermail/zeromq-dev/2013-August/022361.html