### PR TITLE
Don't use zmq 2.x terminology in proxy example

### DIFF
--- a/examples/C/msgqueue.c
+++ b/examples/C/msgqueue.c
@@ -1,5 +1,5 @@
 //  Simple message queuing broker
-//  Same as request-reply broker but using QUEUE device
+//  Same as request-reply broker but using shared queue proxy
 
 #include "zhelpers.h"
 


### PR DESCRIPTION
'Queue device' was a 2.x term used in the `zmq_device` man page. As
`zmq_device` is no longer available in zmq 3/4, let's use terminology
consistent with the `zmq_proxy` man page. This is also more consistent
with the current guide language.