### PR TITLE
fix problems with Java Node Coordination example

### DIFF
--- a/examples/Java/syncsub.java
+++ b/examples/Java/syncsub.java
@@ -12,6 +12,7 @@ public class syncsub{
 
         //  First, connect our subscriber socket
         Socket subscriber = context.socket(ZMQ.SUB);
+        subscriber.setRcvHWM(0);
         subscriber.connect("tcp://localhost:5561");
         subscriber.subscribe("".getBytes());
 


### PR DESCRIPTION
There were two problems where the java subscribers were receiving a low
message count and also not always exiting (implying they weren't
receiving the END message).

Setting a high receive hwm (unlimited for example simplicity) seems to
have resolved both issues, and the subscribers now both receive the full
complement of messages as well as exit correctly.

For reference: http://lists.zeromq.org/pipermail/zeromq-dev/2015-March/028585.html
My guess is all the bindings showing problematic behavior can probably be fixed by tweaking receive hwm.

Thanks!