### PR TITLE
fix minor warnings when building C examples

### DIFF
--- a/examples/C/fileio2.c
+++ b/examples/C/fileio2.c
@@ -20,7 +20,7 @@ client_thread (void *args, zctx_t *ctx, void *pipe)
         //  Ask for next chunk
         zstr_sendm (dealer, "fetch");
         zstr_sendfm (dealer, "%ld", total);
-        zstr_sendf (dealer, "%ld", CHUNK_SIZE);
+        zstr_sendf (dealer, "%d", CHUNK_SIZE);
         
         zframe_t *chunk = zframe_recv (dealer);
         if (!chunk)

--- a/examples/C/fileio3.c
+++ b/examples/C/fileio3.c
@@ -25,7 +25,7 @@ client_thread (void *args, zctx_t *ctx, void *pipe)
             //  Ask for next chunk
             zstr_sendm  (dealer, "fetch");
             zstr_sendfm (dealer, "%ld", offset);
-            zstr_sendf  (dealer, "%ld", CHUNK_SIZE);
+            zstr_sendf  (dealer, "%d", CHUNK_SIZE);
             offset += CHUNK_SIZE;
             credit--;
         }

--- a/examples/C/lpserver.c
+++ b/examples/C/lpserver.c
@@ -5,6 +5,7 @@
 //   - randomly runs slowly, or exits to simulate a crash.
 
 #include "zhelpers.h"
+#include <unistd.h>
 
 int main (void)
 {

--- a/examples/C/mtserver.c
+++ b/examples/C/mtserver.c
@@ -2,6 +2,7 @@
 
 #include "zhelpers.h"
 #include <pthread.h>
+#include <unistd.h>
 
 static void *
 worker_routine (void *context) {

--- a/examples/C/psenvpub.c
+++ b/examples/C/psenvpub.c
@@ -2,6 +2,7 @@
 //  Note that the zhelpers.h file also provides s_sendmore
 
 #include "zhelpers.h"
+#include <unistd.h>
 
 int main (void)
 {

--- a/examples/C/rrworker.c
+++ b/examples/C/rrworker.c
@@ -3,6 +3,7 @@
 //  Expects "Hello" from client, replies with "World"
 
 #include "zhelpers.h"
+#include <unistd.h>
 
 int main (void) 
 {

--- a/examples/C/rtrouter.c
+++ b/examples/C/rtrouter.c
@@ -1,6 +1,7 @@
 //  Cross-connected ROUTER sockets addressing each other
 
 #include "zhelpers.h"
+#include <unistd.h>
 
 int main (void) 
 {

--- a/examples/C/syncsub.c
+++ b/examples/C/syncsub.c
@@ -1,6 +1,7 @@
 //  Synchronized subscriber
 
 #include "zhelpers.h"
+#include <unistd.h>
 
 int main (void)
 {


### PR DESCRIPTION
```
fileio2.c: In function ‘client_thread’:
fileio2.c:23:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Wformat=]
         zstr_sendf (dealer, "%ld", CHUNK_SIZE);
--
fileio3.c: In function ‘client_thread’:
fileio3.c:28:13: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Wformat=]
             zstr_sendf  (dealer, "%ld", CHUNK_SIZE);
--
lpserver.c: In function ‘main’:
lpserver.c:30:13: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
             sleep (2);
--
mtserver.c: In function ‘worker_routine’:
mtserver.c:17:9: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
         sleep (1);
--
psenvpub.c: In function ‘main’:
psenvpub.c:19:9: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
         sleep (1);
--
rrworker.c: In function ‘main’:
rrworker.c:22:9: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
         sleep (1);
--
rtrouter.c: In function ‘main’:
rtrouter.c:19:5: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
     sleep (1);
--
syncsub.c: In function ‘main’:
syncsub.c:15:5: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
     sleep (1);
```