### PR TITLE
Fix Perl, Ruby, and C++ Node Coordination examples

### DIFF
--- a/examples/C++/syncpub.cpp
+++ b/examples/C++/syncpub.cpp
@@ -14,6 +14,10 @@ int main () {
 
     //  Socket to talk to clients
     zmq::socket_t publisher (context, ZMQ_PUB);
+
+    int sndhwm = 0;
+    publisher.setsockopt (ZMQ_SNDHWM, &sndhwm, sizeof (sndhwm));
+
     publisher.bind("tcp://*:5561");
 
     //  Socket to receive signals

--- a/examples/Perl/syncpub.pl
+++ b/examples/Perl/syncpub.pl
@@ -24,6 +24,7 @@ my $context = zmq_init();
 
 # Socket to talk to clients
 my $publisher = zmq_socket($context, ZMQ_PUB);
+zmq_setsockopt($publisher, ZMQ_SNDHWM, 0);
 zmq_bind($publisher, 'tcp://*:5561');
 
 # Socket to receive signals

--- a/examples/Ruby/syncpub.rb
+++ b/examples/Ruby/syncpub.rb
@@ -14,6 +14,7 @@ context = ZMQ::Context.new
 
 # Socket to talk to clients
 publisher = context.socket(ZMQ::PUB)
+publisher.setsockopt(ZMQ::SNDHWM, 0);
 publisher.bind("tcp://*:5561")
 
 # Socket to receive signals


### PR DESCRIPTION
Missing messages and/or subscribers not exiting.

setting high publish sndhwm (unlimited for example simplicity) was
sufficient to fix the issues in all these languages

ref: #537