### PR TITLE
allocation mistake, and unnecessary cast

### DIFF
--- a/examples/C++/hwclient.cpp
+++ b/examples/C++/hwclient.cpp
@@ -18,8 +18,8 @@ int main ()
 
     //  Do 10 requests, waiting each time for a response
     for (int request_nbr = 0; request_nbr != 10; request_nbr++) {
-        zmq::message_t request (6);
-        memcpy ((void *) request.data (), "Hello", 5);
+        zmq::message_t request (5);
+        memcpy (request.data (), "Hello", 5);
         std::cout << "Sending Hello " << request_nbr << "..." << std::endl;
         socket.send (request);
 

--- a/examples/C++/hwserver.cpp
+++ b/examples/C++/hwserver.cpp
@@ -32,7 +32,7 @@ int main () {
 
         //  Send reply back to client
         zmq::message_t reply (5);
-        memcpy ((void *) reply.data (), "World", 5);
+        memcpy (reply.data (), "World", 5);
         socket.send (reply);
     }
     return 0;


### PR DESCRIPTION
In the client, the declaration of message_t request should only allocate 5 bytes in its constructor for the 5 byte Hello message. In both client and server memcpy does not need a c-style void* cast, as the signature of message_t.data() function is already 'inline void *data ()'