### PR TITLE
update code to use latest version, c++ wrapper calls

### DIFF
--- a/examples/C++/msgqueue.cpp
+++ b/examples/C++/msgqueue.cpp
@@ -17,9 +17,9 @@ int main (int argc, char *argv[])
 
     //  Socket facing services
     zmq::socket_t backend (context, ZMQ_DEALER);
-    zmq_bind (backend, "tcp://*:5560");
+    backend.bind("tcp://*:5560");
 
-    //  Start built-in device
-    zmq_device (ZMQ_QUEUE, frontend, backend);
+    //  Start the proxy
+    zmq::proxy(frontend, backend, nullptr);
     return 0;
 }


### PR DESCRIPTION
update the (version 2.1) zmq_device() call, and zmq_bind() function calls, so that in both places the code uses the current C++ wrapper calls