### PR TITLE
Fixed bug in C++ example push/pull workers

### DIFF
--- a/examples/C++/taskwork.cpp
+++ b/examples/C++/taskwork.cpp
@@ -8,6 +8,7 @@
 //  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 //
 #include "zhelpers.hpp"
+#include <string>
 
 int main (int argc, char *argv[])
 {
@@ -28,8 +29,9 @@ int main (int argc, char *argv[])
         int workload;           //  Workload in msecs
 
         receiver.recv(&message);
+        std::string smessage(static_cast<char*>(message.data()), message.size());
 
-        std::istringstream iss(static_cast<char*>(message.data()));
+        std::istringstream iss(smessage);
         iss >> workload;
 
         //  Do the work

--- a/examples/C++/taskwork2.cpp
+++ b/examples/C++/taskwork2.cpp
@@ -5,7 +5,7 @@
 // Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
-
+#include <string>
 
 int main (int argc, char *argv[])
 {
@@ -39,8 +39,9 @@ int main (int argc, char *argv[])
 
             //  Process task
             int workload;           //  Workload in msecs
-            
-            std::istringstream iss(static_cast<char*>(message.data()));
+           
+            std::string sdata(static_cast<char*>(message.data()), message.size());
+            std::istringstream iss(sdata);
             iss >> workload;
 
             //  Do the work


### PR DESCRIPTION
C++ push/pull workers did not take message size into consideration which resulted in wrong workload values due to reading stale memory from previous receives.
