### PR TITLE
Fixed bug C++ traskvent example

### DIFF
--- a/examples/C++/taskvent.cpp
+++ b/examples/C++/taskvent.cpp
@@ -45,6 +45,7 @@ int main (int argc, char *argv[])
         total_msec += workload;
 
         message.rebuild(10);
+        memset(message.data(), '\0', 10);
         sprintf ((char *) message.data(), "%d", workload);
         sender.send(message);
     }


### PR DESCRIPTION
Due to message data not being reinitialized there was a problem when deserializing messages as strings this example's afferent Clojure taskworker.