### PR TITLE
Updating C# Examples: WUClient and WUServer

### DIFF
--- a/examples/C#/wuclient.cs
+++ b/examples/C#/wuclient.cs
@@ -34,6 +34,8 @@ namespace Examples
 					args = new string[] { args[0], "tcp://127.0.0.1:5556" };
 			}
 
+			string endpoint = args[1];
+
 			// Socket to talk to server
 			using (var context = new ZContext())
 			using (var subscriber = new ZSocket(context, ZSocketType.SUB))
@@ -42,12 +44,13 @@ namespace Examples
 				Console.WriteLine("I: Connecting to {0}...", connect_to);
 				subscriber.Connect(connect_to);
 
-				foreach (IPAddress address in WUProxy_GetPublicIPs())
-				{
-					var epgmAddress = string.Format("epgm://{0};239.192.1.1:8100", address);
-					Console.WriteLine("I: Connecting to {0}...", epgmAddress);
-					subscriber.Connect(epgmAddress);
-				}
+				/* foreach (IPAddress address in WUProxy_GetPublicIPs())
+					{
+						var epgmAddress = string.Format("epgm://{0};239.192.1.1:8100", address);
+						Console.WriteLine("I: Connecting to {0}...", epgmAddress);
+						subscriber.Connect(epgmAddress);
+					}
+				} */
 
 				// Subscribe to zipcode
 				string zipCode = args[0];

--- a/examples/C#/wuserver.cs
+++ b/examples/C#/wuserver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 
@@ -27,6 +28,13 @@ namespace Examples
 				string address = "tcp://*:5556";
 				Console.WriteLine("I: Publisher.Bind'ing on {0}", address);
 				publisher.Bind(address);
+
+				/* foreach (IPAddress localAddress in WUProxy_GetPublicIPs())
+				{
+					var epgmAddress = string.Format("epgm://{0};239.192.1.1:8100", localAddress);
+					Console.WriteLine("I: Publisher.Bind'ing on {0}...", epgmAddress);
+					publisher.Bind(epgmAddress);
+				} */
 
 				// Initialize random number generator
 				var rnd = new Random();


### PR DESCRIPTION
Does no more `subscriber.Connect` or `publisher.Bind` to `epgm://{0};239.192.1.1:8100` ...
WUClient does no more return `error = ZError.EPROTONOSUPPORT`.