### PR TITLE
fixed cpp examples build errors

### DIFF
--- a/examples/C++/build
+++ b/examples/C++/build
@@ -3,12 +3,9 @@
 #   Examples build helper
 #   Syntax: build all | clean
 #
-#   Note: may fail with g++/4.0.x, then
-#   build examples using 'g++ -o filename filename.cpp -lzmq'
-#
-ZMQOPTS='-lzmq'
+ZMQOPTS='-lzmq -std=c++11'
 if pkg-config libzmq --exists; then
-  ZMQOPTS=$(pkg-config libzmq --cflags --libs)
+    ZMQOPTS="$(pkg-config libzmq --cflags --libs) -std=c++11"
 fi
 if [ /$1/ = /all/ ]; then
     echo "Building C++ examples..."

--- a/examples/C++/c
+++ b/examples/C++/c
@@ -471,9 +471,9 @@ for i in $*; do
     if [ "$LINKUP" = "yes" ]; then
         TRACE="Linking $FILENAME"
         if [ "$USECPP" = "no" ]; then
-            COMMAND="$CCNAME $CCOPTS $FILENAME.o -o $FILENAME"
+            COMMAND="$CCNAME -o $FILENAME $FILENAME.o $CCOPTS"
         else
-            COMMAND="$CCPLUS $CCOPTS $FILENAME.opp -o $FILENAME"
+            COMMAND="$CCPLUS -o $FILENAME $FILENAME.opp $CCOPTS"
         fi
         case "$LINKTYPE" in
             gnu)


### PR DESCRIPTION
1) added -std=c++11 to support std::thread 2) changed linker output and source files options order to fix 'symbol not found' errors