### PR TITLE
identity examples should reflect current semantics

### DIFF
--- a/chapter3.txt
+++ b/chapter3.txt
@@ -264,7 +264,7 @@ Here is what the program prints:
 ----------------------------------------
 [005] 006B8B4567
 [000]
-[026] ROUTER uses a generated UUID
+[039] ROUTER uses a generated 5 byte identity
 ----------------------------------------
 [005] PEER2
 [000]

--- a/chapter3.txt
+++ b/chapter3.txt
@@ -83,7 +83,7 @@ The {{zmq_socket[3]}} man page describes it thus:
 
 > When receiving messages a ZMQ_ROUTER socket shall prepend a message part containing the identity of the originating peer to the message before passing it to the application. Messages received are fair-queued from among all connected peers. When sending messages a ZMQ_ROUTER socket shall remove the first part of the message and use it to determine the identity of the peer the message shall be routed to.
 
-As a historical note, ZeroMQ v2.2 and earlier use UUIDs as identities, and ZeroMQ v3.0 and later use short integers. There's some impact on network performance, but only when you use multiple proxy hops, which is rare. Mostly the change was to simplify building {{libzmq}} by removing the dependency on a UUID library.
+As a historical note, ZeroMQ v2.2 and earlier use UUIDs as identities. ZeroMQ v3.0 and later generate a 5 byte identity by default (0 + a random 32bit integer). There's some impact on network performance, but only when you use multiple proxy hops, which is rare. Mostly the change was to simplify building {{libzmq}} by removing the dependency on a UUID library.
 
 Identities are a difficult concept to understand, but it's essential if you want to become a ZeroMQ expert. The ROUTER socket //invents// a random identity for each connection with which it works. If there are three REQ sockets connected to a ROUTER socket, it will invent three random identities, one for each REQ socket.
 

--- a/examples/C#/identity.cs
+++ b/examples/C#/identity.cs
@@ -27,7 +27,7 @@ namespace Examples
 				using (var anonymous = new ZSocket(context, ZSocketType.REQ))
 				{
 					anonymous.Connect("inproc://example");
-					anonymous.Send(new ZFrame("ROUTER uses REQ's generated UUID"));
+					anonymous.Send(new ZFrame("ROUTER uses REQ's generated 5 byte identity"));
 				}
 				using (ZMessage msg = sink.ReceiveMessage())
 				{

--- a/examples/C++/identity.cpp
+++ b/examples/C++/identity.cpp
@@ -17,7 +17,7 @@ int main () {
     zmq::socket_t anonymous(context, ZMQ_REQ);
     anonymous.connect( "inproc://example");
 
-    s_send (anonymous, "ROUTER uses a generated UUID");
+    s_send (anonymous, "ROUTER uses a generated 5 byte identity");
     s_dump (sink);
 
     //  Then set the identity ourselves

--- a/examples/C/identity.c
+++ b/examples/C/identity.c
@@ -11,7 +11,7 @@ int main (void)
     //  First allow 0MQ to set the identity
     void *anonymous = zmq_socket (context, ZMQ_REQ);
     zmq_connect (anonymous, "inproc://example");
-    s_send (anonymous, "ROUTER uses a generated UUID");
+    s_send (anonymous, "ROUTER uses a generated 5 byte identity");
     s_dump (sink);
 
     //  Then set the identity ourselves

--- a/examples/CL/identity.lisp
+++ b/examples/CL/identity.lisp
@@ -23,7 +23,7 @@
       ;; First allow 0MQ to set the identity
       (zmq:with-socket (anonymous context zmq:req)
         (zmq:connect anonymous "inproc://example")
-        (send-text anonymous "ROUTER uses a generated UUID")
+        (send-text anonymous "ROUTER uses a generated 5 byte identity")
         (dump-socket sink)
 
         ;; Then set the identity ourselves

--- a/examples/Clojure/identity.clj
+++ b/examples/Clojure/identity.clj
@@ -16,7 +16,7 @@
         identified (mq/socket ctx mq/req)]
     (mq/bind sink "inproc://example")
     (mq/connect anonymous "inproc://example")
-    (mq/send anonymous "ROUTER uses a generated UUID\u0000")
+    (mq/send anonymous "ROUTER uses a generated 5 byte identity\u0000")
     (mq/dump sink)
     (mq/identify identified "PEER2")
     (mq/connect identified "inproc://example")

--- a/examples/Delphi/identity.dpr
+++ b/examples/Delphi/identity.dpr
@@ -26,7 +26,7 @@ begin
   //  First allow 0MQ to set the identity
   anonymous := context.Socket( stReq );
   anonymous.connect( 'inproc://example' );
-  anonymous.send( 'ROUTER uses a generated UUID' );
+  anonymous.send( 'ROUTER uses a generated 5 byte identity' );
   s_dump( sink );
 
   //  Then set the identity ourself

--- a/examples/Erlang/identity.es
+++ b/examples/Erlang/identity.es
@@ -12,7 +12,7 @@ main(_) ->
     %% First allow 0MQ to set the identity
     {ok, Anonymous} = erlzmq:socket(Context, req),
     ok = erlzmq:connect(Anonymous, "inproc://example"),
-    ok = erlzmq:send(Anonymous, <<"ROUTER uses a generated UUID">>),
+    ok = erlzmq:send(Anonymous, <<"ROUTER uses a generated 5 byte identity">>),
     erlzmq_util:dump(Sink),
 
     %% Then set the identity ourselves

--- a/examples/F#/identity.fsx
+++ b/examples/F#/identity.fsx
@@ -19,7 +19,7 @@ let main () =
   // first allow 0MQ to set the identity
   use anonymous = req context
   "inproc://example" |> connect anonymous
-  "ROUTER uses a generated UUID" |> s_send anonymous
+  "ROUTER uses a generated 5 byte identity" |> s_send anonymous
   s_dump sink
 
   // then set the identity ourselves

--- a/examples/Go/identity.go
+++ b/examples/Go/identity.go
@@ -49,7 +49,7 @@ func main() {
 		fmt.Println(err)
 	}
 	anonymous.Connect("inproc://example")
-	err = anonymous.Send([]byte("ROUTER uses a generated UUID"), 0)
+	err = anonymous.Send([]byte("ROUTER uses a generated 5 byte identity"), 0)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/Haskell/identity.hs
+++ b/examples/Haskell/identity.hs
@@ -13,7 +13,7 @@ main =
 
         anonymous <- socket Req
         connect anonymous "inproc://example"
-        send anonymous [] "ROUTER uses a generated UUID" 
+        send anonymous [] "ROUTER uses a generated 5 byte identity" 
 
         dumpSock sink
 

--- a/examples/Haxe/identity.hx
+++ b/examples/Haxe/identity.hx
@@ -29,7 +29,7 @@ class Identity
 		// First allow 0MQ to set the identity
 		var anonymous:ZMQSocket = context.createSocket(ZMQ_REQ);
 		anonymous.connect("inproc://example");
-		anonymous.sendMsg(Bytes.ofString("ROUTER uses a generated UUID"));
+		anonymous.sendMsg(Bytes.ofString("ROUTER uses a generated 5 byte identity"));
 		ZHelpers.dump(sink);
 		
 		// Then set the identity ourselves

--- a/examples/Java/identity.java
+++ b/examples/Java/identity.java
@@ -17,7 +17,7 @@ public class identity {
         Socket anonymous = context.socket(ZMQ.REQ);
 
         anonymous.connect("inproc://example");
-        anonymous.send ("ROUTER uses a generated UUID",0);
+        anonymous.send ("ROUTER uses a generated 5 byte identity",0);
         ZHelper.dump (sink);
 
         //  Then set the identity ourself

--- a/examples/Lua/identity.lua
+++ b/examples/Lua/identity.lua
@@ -16,7 +16,7 @@ sink:bind("inproc://example")
 --  First allow 0MQ to set the identity
 local anonymous = context:socket(zmq.REQ)
 anonymous:connect("inproc://example")
-anonymous:send("ROUTER uses a generated UUID")
+anonymous:send("ROUTER uses a generated 5 byte identity")
 s_dump(sink)
 
 --  Then set the identity ourselves

--- a/examples/Node.js/identity.js
+++ b/examples/Node.js/identity.js
@@ -11,7 +11,7 @@ sink.on("message", zhelpers.dumpFrames);
 //  First allow 0MQ to set the identity
 var anonymous = zmq.socket("req");
 anonymous.connect("inproc://example");
-anonymous.send("ROUTER uses generated UUID");
+anonymous.send("ROUTER uses generated 5 byte identity");
 
 //  Then set the identity ourselves
 var identified = zmq.socket("req");

--- a/examples/PHP/identity.php
+++ b/examples/PHP/identity.php
@@ -15,7 +15,7 @@ $sink->bind("inproc://example");
 //  First allow 0MQ to set the identity
 $anonymous = new ZMQSocket($context, ZMQ::SOCKET_REQ);
 $anonymous->connect("inproc://example");
-$anonymous->send("ROUTER uses a generated UUID");
+$anonymous->send("ROUTER uses a generated 5 byte identity");
 s_dump ($sink);
 
 //  Then set the identity ourselves

--- a/examples/Perl/identity.pl
+++ b/examples/Perl/identity.pl
@@ -20,7 +20,7 @@ zmq_bind($sink, "inproc://example");
 # First allow 0MQ to set the identity
 my $anonymous = zmq_socket($context, ZMQ_REQ);
 zmq_connect($anonymous, "inproc://example");
-zmq_send($anonymous, "ROUTER uses a generated UUID", -1);
+zmq_send($anonymous, "ROUTER uses a generated 5 byte identity", -1);
 s_dump($sink);
 
 # Then set the identity ourselves

--- a/examples/Python/identity.py
+++ b/examples/Python/identity.py
@@ -17,7 +17,7 @@ sink.bind("inproc://example")
 # First allow 0MQ to set the identity
 anonymous = context.socket(zmq.DEALER)
 anonymous.connect("inproc://example")
-anonymous.send(b"ROUTER uses a generated UUID")
+anonymous.send(b"ROUTER uses a generated 5 byte identity")
 zhelpers.dump(sink)
 
 # Then set the identity ourselves

--- a/examples/Q/identity.q
+++ b/examples/Q/identity.q
@@ -7,7 +7,7 @@ port:zsocket.bind[sink; `inproc://example]
 anonymous:zsocket.new[ctx; zmq`REQ]
 zsocket.connect[anonymous; `inproc://example]
 m0:zmsg.new[]
-zmsg.push[m0; zframe.new["ROUTER uses a generated UUID"]]
+zmsg.push[m0; zframe.new["ROUTER uses a generated 5 byte identity"]]
 zmsg.send[m0; anonymous]
 zmsg.dump[zmsg.recv[sink]]
 //  Then set the identity ourselves

--- a/examples/Ruby/identity.rb
+++ b/examples/Ruby/identity.rb
@@ -17,7 +17,7 @@ sink.bind(uri)
 # 0MQ will set the identity here
 anonymous = context.socket(ZMQ::DEALER)
 anonymous.connect(uri)
-anon_message = ZMQ::Message.new("Router uses a generated UUID")
+anon_message = ZMQ::Message.new("ROUTER uses a generated 5 byte identity")
 anonymous.sendmsg(anon_message)
 s_dump(sink)
 

--- a/examples/Scala/identity.scala
+++ b/examples/Scala/identity.scala
@@ -15,7 +15,7 @@ object identity {
 
 	val anonymous = context.socket(ZMQ.REQ)
 	anonymous.connect("inproc://example")
-	anonymous.send("ROUTER uses a generated UUID".getBytes,0)
+	anonymous.send("ROUTER uses a generated 5 byte identity".getBytes,0)
 	dump(sink)
 
 	val identified = context.socket(ZMQ.REQ)

--- a/examples/Tcl/identity.tcl
+++ b/examples/Tcl/identity.tcl
@@ -13,7 +13,7 @@ sink bind "inproc://example"
 # First allow 0MQ to set the identity
 zmq socket anonymous context REQ
 anonymous connect "inproc://example"
-anonymous send "ROUTER uses a generated UUID"
+anonymous send "ROUTER uses a generated 5 byte identity"
 puts "--------------------------------------------------"
 puts [join [sink dump] \n]
 


### PR DESCRIPTION
ROUTER was changed to use generated short ints instead of UUIDs