### PR TITLE
Simplified example to mirror C code example

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -119,3 +119,4 @@ Nathan Stocks
 Ondrej Kupka <ondra.cap@gmail.com>
 Sebastian Thiel <byronimo@gmail.com>
 Scott Watson
+Andriy Drozdyuk <drozzy@gmail.com>

--- a/examples/Python/asyncsrv.py
+++ b/examples/Python/asyncsrv.py
@@ -61,20 +61,7 @@ class ServerTask(threading.Thread):
             worker.start()
             workers.append(worker)
 
-        poll = zmq.Poller()
-        poll.register(frontend, zmq.POLLIN)
-        poll.register(backend,  zmq.POLLIN)
-
-        while True:
-            sockets = dict(poll.poll())
-            if frontend in sockets:
-                ident, msg = frontend.recv_multipart()
-                tprint('Server received %s id %s' % (msg, ident))
-                backend.send_multipart([ident, msg])
-            if backend in sockets:
-                ident, msg = backend.recv_multipart()
-                tprint('Sending to frontend %s id %s' % (msg, ident))
-                frontend.send_multipart([ident, msg])
+        zmq.proxy(frontend, backend)
 
         frontend.close()
         backend.close()


### PR DESCRIPTION
Replaced the poller and while loop with zmq.proxy (https://zeromq.github.io/pyzmq/api/zmq.devices.html) which is python's equivalent to C's code example of zmq_proxy.