### PR TITLE
Windows compatibility for C++ weather update example

### DIFF
--- a/examples/C++/wuserver.cpp
+++ b/examples/C++/wuserver.cpp
@@ -10,6 +10,10 @@
 #include <stdlib.h>
 #include <time.h>
 
+#if (defined (WIN32))
+#include <zhelpers.hpp>
+#endif
+
 #define within(num) (int) ((float) num * random () / (RAND_MAX + 1.0))
 
 int main () {
@@ -18,7 +22,7 @@ int main () {
     zmq::context_t context (1);
     zmq::socket_t publisher (context, ZMQ_PUB);
     publisher.bind("tcp://*:5556");
-    publisher.bind("ipc://weather.ipc");
+    publisher.bind("ipc://weather.ipc");				// Not usable on Windows.
 
     //  Initialize random number generator
     srandom ((unsigned) time (NULL));

--- a/examples/C++/zhelpers.hpp
+++ b/examples/C++/zhelpers.hpp
@@ -37,6 +37,39 @@
 #   define random rand
 #endif
 
+// Visual Studio versions below 2015 do not support sprintf properly. This is a workaround.
+// Taken from http://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+	inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+	{
+		int count = -1;
+
+		if (size != 0)
+			count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+		if (count == -1)
+			count = _vscprintf(format, ap);
+
+		return count;
+	}
+
+	inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+	{
+		int count;
+		va_list ap;
+
+		va_start(ap, format);
+		count = c99_vsnprintf(outBuf, size, format, ap);
+		va_end(ap);
+
+		return count;
+	}
+
+#endif
+
 //  Provide random number from 0..(num-1)
 #define within(num) (int) ((float) (num) * random () / (RAND_MAX + 1.0))
 


### PR DESCRIPTION
Follow-up to issue #581. Added sprintf workaround for Visual Studio to zhelpers.cpp, included it in
wuserver.cpp, added a comment for beginners. This merge allows execution of that example on Windows and with Visual Studio versions below 2015.