### PR TITLE
fixed issue #541, also fixed same issue in clonesrv6.py

### DIFF
--- a/examples/Python/clone.py
+++ b/examples/Python/clone.py
@@ -103,6 +103,7 @@ class CloneServer(object):
         self.snapshot.connect("%s:%i" % (address,port))
         self.subscriber = ctx.socket(zmq.SUB)
         self.subscriber.setsockopt(zmq.SUBSCRIBE, subtree)
+        self.subscriber.setsockopt(zmq.SUBSCRIBE, b'HUGZ')
         self.subscriber.connect("%s:%i" % (address,port+1))
         self.subscriber.linger = 0
 
@@ -162,6 +163,8 @@ class CloneAgent(object):
             key = msg[0]
             value = self.kvmap.get(key)
             self.pipe.send(value.body if value else '')
+        elif command == "SUBTREE":
+            self.subtree = msg[0]
 
 
 # ---------------------------------------------------------------------

--- a/examples/Python/clonesrv5.py
+++ b/examples/Python/clonesrv5.py
@@ -109,8 +109,8 @@ class CloneServer(object):
         self.sequence += 1
         kvmsg.sequence = self.sequence
         kvmsg.send(self.publisher)
-        ttl = kvmsg.get('ttl')
-        if ttl is not None:
+        ttl = float(kvmsg.get('ttl', 0))
+        if ttl:
             kvmsg['ttl'] = time.time() + ttl
         kvmsg.store(self.kvmap)
         logging.info("I: publishing update=%d", self.sequence)
@@ -123,7 +123,8 @@ class CloneServer(object):
     def flush_single(self, kvmsg):
         """If key-value pair has expired, delete it and publish the fact
         to listening clients."""
-        if kvmsg.get('ttl', 0) <= time.time():
+        ttl = float(kvmsg.get('ttl', 0))
+        if ttl and ttl <= time.time():
             kvmsg.body = ""
             self.sequence += 1
             kvmsg.sequence = self.sequence

--- a/examples/Python/clonesrv6.py
+++ b/examples/Python/clonesrv6.py
@@ -142,7 +142,7 @@ class CloneServer(object):
             self.sequence += 1
             kvmsg.sequence = self.sequence
             kvmsg.send(self.publisher)
-            ttl = int(kvmsg.get('ttl'))
+            ttl = float(kvmsg.get('ttl', 0))
             if ttl:
                 kvmsg['ttl'] = time.time() + ttl
             kvmsg.store(self.kvmap)
@@ -175,7 +175,7 @@ class CloneServer(object):
     def flush_single(self, kvmsg):
         """If key-value pair has expired, delete it and publish the fact
         to listening clients."""
-        ttl = int(kvmsg.get('ttl'))
+        ttl = float(kvmsg.get('ttl', 0))
         if ttl and ttl <= time.time():
             kvmsg.body = ""
             self.sequence += 1
@@ -256,9 +256,9 @@ class CloneServer(object):
 
         # Find and remove update off pending list
         kvmsg = KVMsg.from_msg(msg)
-        # update integer ttl -> timestamp
-        ttl = int(kvmsg.get('ttl'))
-        if ttl is not None:
+        # update float ttl -> timestamp
+        ttl = float(kvmsg.get('ttl', 0))
+        if ttl:
             kvmsg['ttl'] = time.time() + ttl
 
         if kvmsg.key != "HUGZ":


### PR DESCRIPTION
#541 
kvmsg.get method returns a string from decoded properties in kvmsg.py. Hence time.time() + ttl raises a TypeError. 
I fixed it by casting to float the returned value of kvmsg.get.  I also set a default value to 0 in the kvmsg.get method to avoid casting a NoneType in case no ttl key can be found.
Also fixed same issue in clonesrv6.py

#327 in clone.py
added subscription to "HUGZ" subtree
added handler of SUBTREE command

Thanks for reviewing these changes.