### PR TITLE
add scripts to list and find missing examples

### DIFF
--- a/bin/check-examples
+++ b/bin/check-examples
@@ -1,0 +1,61 @@
+#! /bin/bash
+#
+#   Prints missing examples for a given language and chapter
+#
+
+set -e
+
+check_script="$(basename ${BASH_SOURCE[0]})"
+zguide_dir="$(dirname ${BASH_SOURCE[0]})/.."
+
+if [[ $# < 2 ]]
+then
+    echo "usage: $check_script <lang> <chapter>"
+    echo "e.g. $check_script Perl 3"
+    exit 1
+fi
+
+lang=$1
+chapter=$2
+
+langdir="$zguide_dir/examples/$lang"
+chfile="$zguide_dir/chapter${chapter}.txt"
+
+if [ ! -d "$langdir" ]
+then
+    echo "No examples found for language '$lang'" 1>&2
+    exit 1
+fi
+
+if [ ! -f "$chfile" ]
+then
+    echo "No chapter file found for chapter '$chapter'" 1>&2
+    exit 1
+fi
+
+examplelist=$($zguide_dir/bin/list-examples $chapter)
+missing=0
+
+IFS=$'\n'
+for ex in $examplelist
+do
+    unset IFS
+
+    examplefile="$(cut -d= -f1 <<< $ex)"
+    examplename="$(cut -d= -f2 <<< $ex)"
+    examplepath="$zguide_dir/examples/$lang/${examplefile}"
+
+    if [[ -z "$(ls ${examplepath}.* 2>/dev/null)" ]]
+    then
+        printf "Missing %-12s %s\n" "$examplefile:" "$examplename" 1>&2
+        missing=1
+    fi
+done
+
+if [ $missing -eq 1 ]
+then
+    exit 1
+else
+    echo "OK" 1>&2
+    exit 0
+fi

--- a/bin/list-examples
+++ b/bin/list-examples
@@ -1,0 +1,31 @@
+#! /bin/bash
+#
+#   Prints the names of all examples in a chapter
+#
+
+set -e
+
+check_script="$(basename ${BASH_SOURCE[0]})"
+zguide_dir="$(dirname ${BASH_SOURCE[0]})/.."
+
+if [[ $# < 1 ]]
+then
+    echo "usage: $check_script <chapter>"
+    echo "e.g. $check_script 3"
+    exit 1
+fi
+
+chapter=$1
+chfile="$zguide_dir/chapter${chapter}.txt"
+
+if [ ! -f "$chfile" ]
+then
+    echo "No chapter file found for chapter '$chapter'" 1>&2
+    exit 1
+fi
+
+grep 'type="example"' $chfile | \
+    perl -nE \
+      'my @ex=/name="([^"]+)"/;push @ex,/title="([^"]+)"/;say join "=", @ex' \
+      | uniq
+


### PR DESCRIPTION
I have a couple scripts I've been using locally to find missing examples.  I thought they may be useful enough to add to the existing zguide bin scripts.

*check-examples* - list missing examples for a given language and chapter
*list-examples* - list all examples for a chapter

```
calid@arch ~/git/zguide
$ bin/check-examples C 3
OK

calid@arch ~/git/zguide
$ bin/check-examples Python 3
OK

calid@arch ~/git/zguide
$ bin/check-examples Perl 3
Missing lbbroker2:   Load balancing broker using high-level API
Missing lbbroker3:   Load balancing broker using zloop
Missing asyncsrv:    Asynchronous client/server
Missing peering1:    Prototype state flow
Missing peering2:    Prototype local and cloud flow
Missing peering3:    Full cluster simulation

calid@arch ~/git/zguide
$ bin/check-examples Ruby 3
Missing lbbroker2:   Load balancing broker using high-level API
Missing lbbroker3:   Load balancing broker using zloop

calid@arch ~/git/zguide
$ bin/list-examples 3
identity=Identity check
rtreq=ROUTER-to-REQ
rtdealer=ROUTER-to-DEALER
lbbroker=Load balancing broker
lbbroker2=Load balancing broker using high-level API
lbbroker3=Load balancing broker using zloop
asyncsrv=Asynchronous client/server
peering1=Prototype state flow
peering2=Prototype local and cloud flow
peering3=Full cluster simulation
```
