### PR TITLE
Add manually cleanup for taskwork2.py/tasksink2.py

### DIFF
--- a/examples/Python/tasksink2.py
+++ b/examples/Python/tasksink2.py
@@ -45,4 +45,6 @@ print("Total elapsed time: %d msec" % total_msec)
 controller.send(b"KILL")
 
 # Finished
-time.sleep(1)  # Give 0MQ time to deliver
+receiver.close()
+controller.close()
+context.term()

--- a/examples/Python/taskwork2.py
+++ b/examples/Python/taskwork2.py
@@ -52,3 +52,9 @@ while True:
     # Any waiting controller command acts as 'KILL'
     if socks.get(controller) == zmq.POLLIN:
         break
+
+# Finished
+receiver.close()
+sender.close()
+controller.close()
+context.term()


### PR DESCRIPTION
BTW, i think using the context manager for `context` and `socket` is the more pythonic way.