### PR TITLE
Problem: lvcache has errors in C/C#/Ruby code examples

### DIFF
--- a/examples/C#/lvcache.cs
+++ b/examples/C#/lvcache.cs
@@ -24,7 +24,7 @@ namespace Examples
 			using (var backend = new ZSocket(context, ZSocketType.XPUB))
 			{
 				// Subscribe to every single topic from publisher
-				frontend.Bind("tcp://*:5557");
+				frontend.Connect("tcp://*:5557");
 				frontend.SubscribeAll();
 
 				backend.Bind("tcp://*:5558");

--- a/examples/C/lvcache.c
+++ b/examples/C/lvcache.c
@@ -7,7 +7,7 @@ int main (void)
 {
     zctx_t *context = zctx_new ();
     void *frontend = zsocket_new (context, ZMQ_SUB);
-    zsocket_bind (frontend, "tcp://*:5557");
+    zsocket_connect (frontend, "tcp://*:5557");
     void *backend = zsocket_new (context, ZMQ_XPUB);
     zsocket_bind (backend, "tcp://*:5558");
 

--- a/examples/Ruby/lvcache.rb
+++ b/examples/Ruby/lvcache.rb
@@ -8,7 +8,7 @@ require 'ffi-rzmq'
 context = ZMQ::Context.new
 
 frontend = context.socket(ZMQ::SUB)
-frontend.bind("tcp://*:5557")
+frontend.connect("tcp://*:5557")
 backend = context.socket(ZMQ::XPUB)
 backend.bind("tcp://*:5558")
 


### PR DESCRIPTION
**Solution:** change lvcache.{c|cs|rb} to call connect on frontend instead of
bind, since the latter is already done. Other language examples of lvcache
already fixed in pull request #624. First reported in zeromq/libzmq#1787.