### PR TITLE
Python 3 compatibility for Clone pattern models 6 and 5

### DIFF
--- a/examples/Python/clonecli6.py
+++ b/examples/Python/clonecli6.py
@@ -15,15 +15,15 @@ SUBTREE = "/client/"
 def main():
     # Create and connect clone
     clone = Clone()
-    clone.subtree = SUBTREE
+    clone.subtree = SUBTREE.encode()
     clone.connect("tcp://localhost", 5556)
     clone.connect("tcp://localhost", 5566)
 
     try:
         while True:
             # Distribute as key-value message
-            key = "%d" % random.randint(1,10000)
-            value = "%d" % random.randint(1,1000000)
+            key = b"%d" % random.randint(1,10000)
+            value = b"%d" % random.randint(1,1000000)
             clone.set(key, value, random.randint(0,30))
             time.sleep(1)
     except KeyboardInterrupt:

--- a/examples/Python/clonesrv5.py
+++ b/examples/Python/clonesrv5.py
@@ -81,8 +81,8 @@ class CloneServer(object):
 
     def handle_snapshot(self, msg):
         """snapshot requests"""
-        if len(msg) != 3 or msg[1] != "ICANHAZ?":
-            print "E: bad request, aborting"
+        if len(msg) != 3 or msg[1] != b"ICANHAZ?":
+            print("E: bad request, aborting")
             dump(msg)
             self.loop.stop()
             return
@@ -99,7 +99,7 @@ class CloneServer(object):
             logging.info("I: Sending state shapshot=%d" % self.sequence)
             self.snapshot.send(identity, zmq.SNDMORE)
             kvmsg = KVMsg(self.sequence)
-            kvmsg.key = "KTHXBAI"
+            kvmsg.key = b"KTHXBAI"
             kvmsg.body = subtree
             kvmsg.send(self.snapshot)
 
@@ -109,23 +109,24 @@ class CloneServer(object):
         self.sequence += 1
         kvmsg.sequence = self.sequence
         kvmsg.send(self.publisher)
-        ttl = float(kvmsg.get('ttl', 0))
+        ttl = float(kvmsg.get(b'ttl', 0))
         if ttl:
-            kvmsg['ttl'] = time.time() + ttl
+            kvmsg[b'ttl'] = b'%f' % (time.time() + ttl)
         kvmsg.store(self.kvmap)
         logging.info("I: publishing update=%d", self.sequence)
 
     def flush_ttl(self):
         """Purge ephemeral values that have expired"""
-        for key,kvmsg in self.kvmap.items():
+        for key,kvmsg in list(self.kvmap.items()):
+            # used list() to exhaust the iterator before deleting from the dict
             self.flush_single(kvmsg)
 
     def flush_single(self, kvmsg):
         """If key-value pair has expired, delete it and publish the fact
         to listening clients."""
-        ttl = float(kvmsg.get('ttl', 0))
+        ttl = float(kvmsg.get(b'ttl', 0))
         if ttl and ttl <= time.time():
-            kvmsg.body = ""
+            kvmsg.body = b""
             self.sequence += 1
             kvmsg.sequence = self.sequence
             kvmsg.send(self.publisher)


### PR DESCRIPTION
Making these two systems Python 3-compatible consists entirely of print_function- and bytes-related changes, though some of the latter are a tad less trivial than normal since Python's numeric types lack a `__bytes__` method.